### PR TITLE
docs: DSAPP-100 & DSAPP-21 URLs for App Versions

### DIFF
--- a/_examples/other/content.jsonc
+++ b/_examples/other/content.jsonc
@@ -65,8 +65,8 @@
             "label": "Software Variant B",
             "description": "Runs an app and responds to errors in false time."
             //, { "url": "https://jupyter.designsafe-ci.org/.../SOFTWARE_VARIANT_B.ipynb" }
-            // providers, "url" means the [Get Started] button should directly open that URL (instead of opening an app or a notice and a [Launch] button in the /workspace/)
-            // developers, "url" should be entered in the "External HREF:" field (even if it is an internal path)
+            // "url" means the [Get Started] button should directly open that URL (instead of opening an app or a notice and a [Launch] button in the /workspace/)
+            // For CMS Editors: "url" is the "External HREF:" field (even if it is an internal path)
         }
     ],
     "related_apps": [

--- a/_examples/other/content.jsonc
+++ b/_examples/other/content.jsonc
@@ -64,6 +64,9 @@
         {
             "label": "Software Variant B",
             "description": "Runs an app and responds to errors in false time."
+            //, { "url": "https://jupyter.designsafe-ci.org/.../SOFTWARE_VARIANT_B.ipynb" }
+            // providers, "url" means the [Get Started] button should directly open that URL (instead of opening an app or a notice and a [Launch] button in the /workspace/)
+            // developers, "url" should be entered in the "External HREF:" field (even if it is an internal path)
         }
     ],
     "related_apps": [

--- a/_examples/simcenter/content.jsonc
+++ b/_examples/simcenter/content.jsonc
@@ -49,7 +49,8 @@
     "versions": [
         {
             "label": "______ (Download)",
-            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources."
+            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources.",
+            "url": "/data/browser/public/designsafe.storage.community/SimCenter/Software/____"
         },
         {
             "label": "______ (Web Portal)",

--- a/ee-uq/content.jsonc
+++ b/ee-uq/content.jsonc
@@ -55,7 +55,8 @@
     "versions": [
         {
             "label": "EE-UQ (Download)",
-            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources."
+            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources.",
+            "url": "/data/browser/public/designsafe.storage.community/SimCenter/Software/EE_UQ"
         },
         {
             "label": "EE-UQ (Web Portal)",

--- a/ground-motion-portal/content.jsonc
+++ b/ground-motion-portal/content.jsonc
@@ -43,6 +43,7 @@
     ],
     "versions": [
         {
+            // "label": "SCEC BBP Ground-Motion Portal",
             "url": "https://jupyter.designsafe-ci.org/hub/user-redirect/lab/tree/CommunityData/SCEC_BBP_GMportal/SCEC_BBP_GMportal_R2025.ipynb"
         }
     ],

--- a/ground-motion-portal/content.jsonc
+++ b/ground-motion-portal/content.jsonc
@@ -41,7 +41,11 @@
             "citation": "Maechling, P. J., F. Silva, S. Callaghan, and T. H. Jordan (2015). SCEC Broadband Platform: System Architecture and Software Implementation, Seismol. Res. Lett., 86, no. 1, doi: 10.1785/0220140125"
         }
     ],
-    "versions": [],
+    "versions": [
+        {
+            "url": "https://jupyter.designsafe-ci.org/hub/user-redirect/lab/tree/CommunityData/SCEC_BBP_GMportal/SCEC_BBP_GMportal_R2025.ipynb"
+        }
+    ],
     "related_apps": [
         "jupyter"
     ]

--- a/hydro-uq/content.jsonc
+++ b/hydro-uq/content.jsonc
@@ -43,7 +43,8 @@
     "versions": [
         {
             "label": "Hydro-UQ (Download)",
-            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources."
+            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources.",
+            "url": "/data/browser/public/designsafe.storage.community/SimCenter/Software/HydroUQ"
         },
         {
             "label": "Hydro-UQ (Web Portal)",

--- a/pbe/content.jsonc
+++ b/pbe/content.jsonc
@@ -53,7 +53,8 @@
     "versions": [
         {
             "label": "PBE (Download)",
-            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources."
+            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources.",
+            "url": "/data/browser/public/designsafe.storage.community/SimCenter/Software/PBE"
         },
         {
             "label": "PBE (Web Portal)",

--- a/quofem/content.jsonc
+++ b/quofem/content.jsonc
@@ -40,7 +40,8 @@
     "versions": [
         {
             "label": "quoFEM (Download)",
-            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources."
+            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources.",
+            "url": "/data/browser/public/designsafe.storage.community/SimCenter/Software/quoFEM"
         },
         {
             "label": "quoFEM (Web Portal)",

--- a/r2d/content.jsonc
+++ b/r2d/content.jsonc
@@ -40,7 +40,8 @@
     "versions": [
         {
             "label": "R2D (Download)",
-            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources."
+            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources.",
+            "url": "/data/browser/public/designsafe.storage.community/SimCenter/Software/R2Dt"
         },
         {
             "label": "R2D (Web Portal)",

--- a/we-uq/content.jsonc
+++ b/we-uq/content.jsonc
@@ -42,7 +42,8 @@
     "versions": [
         {
             "label": "WE-UQ (Download)",
-            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources."
+            "description": "Downloadable app that performs simulations locally or on DesignSafe computing resources.",
+            "url": "/data/browser/public/designsafe.storage.community/SimCenter/Software/WE_UQ"
         },
         {
             "label": "WE-UQ (Web Portal)",


### PR DESCRIPTION
## Goal

Track URLs for apps that directly open from overview page.

## Related

- [DSAPP-100](https://tacc-main.atlassian.net/browse/DSAPP-100)
- [DSAPP-21](https://tacc-main.atlassian.net/browse/DSAPP-21)

## Changes

- **added** property `"url"` in select `"versions"` objects