### PR TITLE
feat: link to user guide in workspace until WA-356

### DIFF
--- a/_examples/other/workspace.html
+++ b/_examples/other/workspace.html
@@ -8,3 +8,6 @@
 <p>This software runs in a different environment. You may be prompted to login.</p>
 <p>“Launch” opens a third-party application. DesignSafe is not responsible for the content or security of third-party websites.</p>
 -->
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://docs.tacc.utexas.edu/software/some_app/" target="_blank">User Guide</a></p>

--- a/_examples/simcenter/workspace.html
+++ b/_examples/simcenter/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="/data/browser/public/designsafe.storage.community/SimCenter/Software/________" target="_blank">Launch</a></p>
 
 <p>SimCenter tools are downloaded to your local computer and interface with DesignSafe Resources through the underlying API.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://docs.tacc.utexas.edu/software/some_app/" target="_blank">User Guide</a></p>

--- a/ansys/workspace.html
+++ b/ansys/workspace.html
@@ -5,3 +5,6 @@
 <p>TACC's ANSYS license is available only for non-commercial, academic use. To access ANSYS please provide your  institutional affiliation and a brief statement confirming that you will use ANSYS only for non-commercial, academic purposes.</p>
 
 <p><strong>After activation</strong>, you can access ANSYS on <a href="https://portal.tacc.utexas.edu/software/ansys" target="_blank">Frontera command line</a>.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://docs.tacc.utexas.edu/software/ansys/" target="_blank">User Guide</a></p>

--- a/ee-uq/workspace.html
+++ b/ee-uq/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="/data/browser/public/designsafe.storage.community/SimCenter/Software/EE_UQ" target="_blank">Launch</a></p>
 
 <p>SimCenter tools are downloaded to your local computer and interface with DesignSafe Resources through the underlying API.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://nheri-simcenter.github.io/EE-UQ-Documentation/" target="_blank">User Guide</a></p>

--- a/ground-motion-portal/workspace.html
+++ b/ground-motion-portal/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="https://jupyter.designsafe-ci.org/hub/user-redirect/lab/tree/CommunityData/SCEC_BBP_GMportal/SCEC_BBP_GMportal_R2025.ipynb" target="_blank">Launch</a></p>
 
 <p>This software runs in a different environment. You may be prompted to login.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://designsafe-ci.org/user-guide/tools/hazard/#scec" target="_blank">User Guide</a></p>

--- a/hazmapper/workspace.html
+++ b/hazmapper/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="https://hazmapper.tacc.utexas.edu/hazmapper/" target="_blank">Launch</a></p>
 
 <p>This software runs in a different environment. You may be prompted to login.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://designsafe-ci.org/user-guide/tools/visualization/#hazmapper-user-guide" target="_blank">User Guide</a></p>

--- a/hvsweb/workspace.html
+++ b/hvsweb/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="https://hvsrweb.designsafe-ci.org/" target="_blank">Launch</a></p>
 
 <p>“Launch” opens a third-party application. DesignSafe is not responsible for its content or security.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://www.designsafe-ci.org/user-guide/analysis/#hvsrweb-user-guide" target="_blank">User Guide</a></p>

--- a/jupyter/workspace.html
+++ b/jupyter/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="https://jupyter.designsafe-ci.org/" target="_blank">Launch</a></p>
 
 <p>This software runs in a different environment. You may be prompted to login.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://designsafe-ci.org/user-guide/tools/jupyterhub/" target="_blank">User Guide</a></p>

--- a/next-generation-liquefaction/workspace.html
+++ b/next-generation-liquefaction/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="https://jupyter.designsafe-ci.org/hub/user-redirect/lab/tree/CommunityData/NGL" target="_blank">Launch</a></p>
 
 <p>This software runs in a different environment. You may be prompted to login.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://designsafe-ci.org/user-guide/tools/hazard/#liquefaction" target="_blank">User Guide</a></p>

--- a/tpu-wind-databases/workspace.html
+++ b/tpu-wind-databases/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="http://www.wind.arch.t-kougei.ac.jp/system/eng/contents/code/tpu" target="_blank">Launch</a></p>
 
 <p>“Launch” opens a third-party application. DesignSafe is not responsible for its content or security.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://www.designsafe-ci.org/user-guide/tools/hazard/#tpu" target="_blank">User Guide</a></p>

--- a/vortex-winds-dedm-hr/workspace.html
+++ b/vortex-winds-dedm-hr/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="http://evovw.ce.nd.edu/dadm/VW_design6_noauth1.html" target="_blank">Launch</a></p>
 
 <p>“Launch” opens a third-party application. DesignSafe is not responsible for its content or security.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://www.designsafe-ci.org/user-guide/tools/hazard/#vortex" target="_blank">User Guide</a></p>


### PR DESCRIPTION
## Overview

Restored links to user guide.

## Notes

This links should eventually be **deleted**, but **only after** [WA-356](https://tacc-main.atlassian.net/browse/WA-356) is deployed, otherwise link is just missing, not moved. (And such a change is not approved yet.)

## Related

- [WA-356](https://tacc-main.atlassian.net/browse/WA-356)