### PR TITLE
feat: link to user guide in workspace until WA-356 - SimCenter & Taggit

### DIFF
--- a/hydro-uq/workspace.html
+++ b/hydro-uq/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="/data/browser/public/designsafe.storage.community/SimCenter/Software/HydroUQ" target="_blank">Launch</a></p>
 
 <p>SimCenter tools are downloaded to your local computer and interface with DesignSafe Resources through the underlying API.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://nheri-simcenter.github.io/Hydro-Documentation/" target="_blank">User Guide</a></p>

--- a/pbe/workspace.html
+++ b/pbe/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="/data/browser/tapis/designsafe.storage.community/SimCenter/Software/PBE" target="_blank">Launch</a></p>
 
 <p>SimCenter tools are downloaded to your local computer and interface with DesignSafe Resources through the underlying API.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://nheri-simcenter.github.io/PBE-Documentation/" target="_blank">User Guide</a></p>

--- a/quofem/workspace.html
+++ b/quofem/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="/data/browser/tapis/designsafe.storage.community/SimCenter/Software/quoFEM" target="_blank">Launch</a></p>
 
 <p>SimCenter tools are downloaded to your local computer and interface with DesignSafe Resources through the underlying API.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://nheri-simcenter.github.io/quoFEM-Documentation/" target="_blank">User Guide</a></p>

--- a/r2d/workspace.html
+++ b/r2d/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="/data/browser/tapis/designsafe.storage.community/SimCenter/Software/R2Dt" target="_blank">Launch</a></p>
 
 <p>SimCenter tools are downloaded to your local computer and interface with DesignSafe Resources through the underlying API.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://nheri-simcenter.github.io/R2D-Documentation/" target="_blank">User Guide</a></p>

--- a/taggit/workspace.html
+++ b/taggit/workspace.html
@@ -3,3 +3,7 @@
 <p><a class="btn btn-success" href="https://hazmapper.tacc.utexas.edu/taggit/" target="_blank">Launch</a></p>
 
 <p>This software runs in a different environment. You may be prompted to login.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="
+https://designsafe-ci.org/user-guide/tools/visualization/#taggit-user-guide-basic-image-browsing-and-mapping" target="_blank">User Guide</a></p>

--- a/we-uq/workspace.html
+++ b/we-uq/workspace.html
@@ -3,3 +3,6 @@
 <p><a class="btn btn-success" href="/data/browser/tapis/designsafe.storage.community/SimCenter/Software/WE_UQ" target="_blank">Launch</a></p>
 
 <p>SimCenter tools are downloaded to your local computer and interface with DesignSafe Resources through the underlying API.</p>
+
+<!-- IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 -->
+<p><a class="btn btn-secondary" href="https://nheri-simcenter.github.io/WE-UQ-Documentation/" target="_blank">User Guide</a></p>


### PR DESCRIPTION
## Overview

Added links to user guide.

## Notes

This links should eventually be **deleted**, but **only after** [WA-356](https://tacc-main.atlassian.net/browse/WA-356) is deployed, otherwise user has no link to any help of any kind. (And such a change is not approved yet.)

## Related

- [WA-356](https://tacc-main.atlassian.net/browse/WA-356)