### PR TITLE
feat(workspace): align user guide button top-right

### DIFF
--- a/_assets/workspace.css
+++ b/_assets/workspace.css
@@ -1,1 +1,17 @@
 /* STYLES FOR WORKSPACE.HTML */
+
+/* to align manual User Guide button to top right edge */
+/* IMPORTANT: Remove this upon DEPLOY of DesignSafe-CI/portal#1556 */
+[class*="html-app-container"] {
+    --space-between-content-and-right-edge: 1em;
+
+    position: relative;
+}
+[class*="html-app-container"] p:has(.btn-secondary) {
+    position: absolute;
+    right: var(--space-between-content-and-right-edge);
+    top: 0;
+}
+[class*="html-app-container"] p {
+    margin-right: var(--space-between-content-and-right-edge);
+}


### PR DESCRIPTION
## Overview

Aligned "User Guide" link to top-right of content.

> [!IMPORTANT]
> **After** [WA-356](https://tacc-main.atlassian.net/browse/WA-356) is deployed, then **either** revert this **or** delete these styles.[^1]

[^1]: After [WA-356](https://tacc-main.atlassian.net/browse/WA-356), these links will be removed so need not be positoned like this.

## UI

| before | after |
| - | - |
| <img width="960" alt="before" src="https://github.com/user-attachments/assets/3d25609f-2d8c-407f-a261-a8433eb81103" /> | <img width="960" alt="after" src="https://github.com/user-attachments/assets/5b2ae810-6f0c-48bf-9d5d-85b8b2cfd6b7" /> |

## Related

- #20
- #21