### PR TITLE
docs(opensees): interactive, rename and redescribe

### DIFF
--- a/opensees/content.jsonc
+++ b/opensees/content.jsonc
@@ -65,8 +65,8 @@
     ],
     "versions": [
         {
-            "label": "Interactive VM for OpenSees",
-            "description": "Runs OpenSees interactively and responds to errors in real time. If your connection fails, please use JupyterHub instead."
+            "label": "OpenSees on JupyterHub",
+            "description": "Run OpenSees interactively in a Jupyter environment."
         },
         {
             "label": "OpenSees-EXPRESS (VM)",


### PR DESCRIPTION
Rename and new description for OpenSees Interactive VM, whcih will now be run on JupyterHub.