### PR TITLE
fix: need space between content & scrollbar

### DIFF
--- a/_assets/workspace.css
+++ b/_assets/workspace.css
@@ -1,1 +1,10 @@
 /* STYLES FOR WORKSPACE.HTML */
+
+/* To add space between "View User Guide" and scrollbar */
+.ant-layout                         /* (the wrapper to which to add space) */
+:not(:has(.ant-layout))             /* (not the outermost one) */
+:has([class*="html-app-container"]) /* (the one with CMS editor content) */ {
+    /* value from `gap: 20px` */
+    /* https://github.com/DesignSafe-CI/portal/blob/v7.5.2/client/src/workspace/layouts/WorkspaceBaseLayout.tsx#L75 */
+    padding-right: 20px;
+}


### PR DESCRIPTION
- add space between content and scrollbar
- fix since https://github.com/DesignSafe-CI/portal-apps-user-content/pull/25
- using a value from https://github.com/DesignSafe-CI/portal/blob/v7.5.2/client/src/workspace/layouts/WorkspaceBaseLayout.tsx#L75

https://github.com/user-attachments/assets/f5aa4f55-7eb2-4cfa-ac9a-921428d6e83a

<sup>Rather than suffer [DesignSafe-Ci/portal](https://github.com/DesignSafe-CI/portal) styling practices, I add content-specific styling via this stylesheet which is loaded via CDN URL by each HTML/External app.</sup>